### PR TITLE
CTCP-249: Set default port for application to match Service Manager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     majorVersion                     := 0,
     scalaVersion                     := "2.12.15",
+    PlayKeys.playDefaultPort         := 9496,
     libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
     // ***************
     // Use the silencer plugin to suppress warnings


### PR DESCRIPTION
Found that 9496 is currently not in use.