### PR TITLE
CTCP-1541: Fix date-time and date only fields in Json schema not validating if a date or time is actually valid.

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateFormat.scala
+++ b/app/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateFormat.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsvalidator.services.jsonformats
+
+import com.networknt.schema.AbstractFormat
+
+import java.time.LocalDate
+import scala.util.Try
+
+object DateFormat extends AbstractFormat("date", "- date provided is invalid.") {
+  override def matches(value: String): Boolean = Try(LocalDate.parse(value)).isSuccess
+}

--- a/app/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateTimeFormat.scala
+++ b/app/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateTimeFormat.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsvalidator.services.jsonformats
+
+import com.networknt.schema.AbstractFormat
+
+import java.time.LocalDateTime
+import scala.util.Try
+
+object DateTimeFormat extends AbstractFormat("date-time", "- date or time provided is invalid.") {
+
+  override def matches(value: String): Boolean = Try(LocalDateTime.parse(value)).isSuccess
+}

--- a/conf/json/cc004c-schema.json
+++ b/conf/json/cc004c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2369,7 +2377,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2557,7 +2566,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6997,7 +7007,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8772,17 +8783,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8827,12 +8841,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8859,7 +8875,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9115,7 +9132,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9273,7 +9291,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9393,12 +9412,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9633,7 +9654,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11429,7 +11451,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13526,7 +13549,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14005,7 +14029,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14021,7 +14046,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14062,22 +14088,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14464,7 +14494,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15094,7 +15125,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15111,12 +15143,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15409,12 +15443,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15897,12 +15933,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16111,7 +16149,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16122,7 +16161,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16132,7 +16172,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16316,12 +16357,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16466,7 +16509,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16520,7 +16564,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16928,7 +16973,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17323,7 +17369,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20182,7 +20229,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20234,7 +20282,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20288,12 +20337,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20329,7 +20380,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20349,7 +20401,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc007c-schema.json
+++ b/conf/json/cc007c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2375,7 +2383,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2563,7 +2572,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7003,7 +7013,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8778,17 +8789,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8833,12 +8847,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8865,7 +8881,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9121,7 +9138,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9279,7 +9297,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9399,12 +9418,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9639,7 +9660,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11435,7 +11457,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13532,7 +13555,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14011,7 +14035,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14027,7 +14052,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14068,22 +14094,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14470,7 +14500,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15100,7 +15131,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15117,12 +15149,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15415,12 +15449,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15903,12 +15939,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16117,7 +16155,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16128,7 +16167,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16138,7 +16178,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16322,12 +16363,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16472,7 +16515,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16526,7 +16570,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16934,7 +16979,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17329,7 +17375,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20188,7 +20235,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20240,7 +20288,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20294,12 +20343,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20335,7 +20386,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20355,7 +20407,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc009c-schema.json
+++ b/conf/json/cc009c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2373,7 +2381,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2561,7 +2570,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7001,7 +7011,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8776,17 +8787,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8831,12 +8845,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8863,7 +8879,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9119,7 +9136,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9277,7 +9295,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9397,12 +9416,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9637,7 +9658,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11433,7 +11455,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13530,7 +13553,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14009,7 +14033,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14025,7 +14050,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14066,22 +14092,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14468,7 +14498,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15098,7 +15129,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15115,12 +15147,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15413,12 +15447,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15901,12 +15937,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16115,7 +16153,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16126,7 +16165,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16136,7 +16176,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16320,12 +16361,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16470,7 +16513,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16524,7 +16568,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16932,7 +16977,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17327,7 +17373,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20186,7 +20233,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20238,7 +20286,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20292,12 +20341,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20333,7 +20384,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20353,7 +20405,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc013c-schema.json
+++ b/conf/json/cc013c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2402,7 +2410,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2590,7 +2599,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7030,7 +7040,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8805,17 +8816,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8860,12 +8874,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8892,7 +8908,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9148,7 +9165,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9306,7 +9324,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9426,12 +9445,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9666,7 +9687,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11462,7 +11484,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13559,7 +13582,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14038,7 +14062,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14054,7 +14079,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14095,22 +14121,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14497,7 +14527,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15127,7 +15158,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15144,12 +15176,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15442,12 +15476,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15930,12 +15966,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16144,7 +16182,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16155,7 +16194,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16165,7 +16205,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16349,12 +16390,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16499,7 +16542,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16553,7 +16597,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16961,7 +17006,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17356,7 +17402,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20215,7 +20262,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20267,7 +20315,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20321,12 +20370,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20362,7 +20413,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20382,7 +20434,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc014c-schema.json
+++ b/conf/json/cc014c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2369,7 +2377,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2557,7 +2566,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6997,7 +7007,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8772,17 +8783,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8827,12 +8841,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8859,7 +8875,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9115,7 +9132,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9273,7 +9291,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9393,12 +9412,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9633,7 +9654,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11429,7 +11451,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13526,7 +13549,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14005,7 +14029,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14021,7 +14046,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14062,22 +14088,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14464,7 +14494,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15094,7 +15125,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15111,12 +15143,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15409,12 +15443,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15897,12 +15933,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16111,7 +16149,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16122,7 +16161,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16132,7 +16172,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16316,12 +16357,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16466,7 +16509,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16520,7 +16564,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16928,7 +16973,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17323,7 +17369,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20182,7 +20229,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20234,7 +20282,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20288,12 +20337,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20329,7 +20380,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20349,7 +20401,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc015c-schema.json
+++ b/conf/json/cc015c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2402,7 +2410,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2590,7 +2599,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7030,7 +7040,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8805,17 +8816,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8860,12 +8874,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8892,7 +8908,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9148,7 +9165,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9306,7 +9324,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9426,12 +9445,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9666,7 +9687,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11462,7 +11484,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13559,7 +13582,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14038,7 +14062,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14054,7 +14079,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14095,22 +14121,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14497,7 +14527,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15127,7 +15158,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15144,12 +15176,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15442,12 +15476,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15930,12 +15966,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16144,7 +16182,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16155,7 +16194,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16165,7 +16205,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16349,12 +16390,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16499,7 +16542,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16553,7 +16597,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16961,7 +17006,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17356,7 +17402,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20215,7 +20262,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20267,7 +20315,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20321,12 +20370,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20362,7 +20413,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20382,7 +20434,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc017c-schema.json
+++ b/conf/json/cc017c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2392,7 +2400,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2580,7 +2589,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7020,7 +7030,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8795,17 +8806,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8850,12 +8864,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8882,7 +8898,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9138,7 +9155,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9296,7 +9314,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9416,12 +9435,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9656,7 +9677,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11452,7 +11474,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13549,7 +13572,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14028,7 +14052,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14044,7 +14069,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14085,22 +14111,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14487,7 +14517,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15117,7 +15148,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15134,12 +15166,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15432,12 +15466,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15920,12 +15956,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16134,7 +16172,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16145,7 +16184,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16155,7 +16195,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16339,12 +16380,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16489,7 +16532,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16543,7 +16587,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16951,7 +16996,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17346,7 +17392,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20205,7 +20252,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20257,7 +20305,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20311,12 +20360,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20352,7 +20403,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20372,7 +20424,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc019c-schema.json
+++ b/conf/json/cc019c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc022c-schema.json
+++ b/conf/json/cc022c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2375,7 +2383,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2563,7 +2572,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7003,7 +7013,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8778,17 +8789,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8833,12 +8847,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8865,7 +8881,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9121,7 +9138,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9279,7 +9297,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9399,12 +9418,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9639,7 +9660,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11435,7 +11457,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13532,7 +13555,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14011,7 +14035,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14027,7 +14052,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14068,22 +14094,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14470,7 +14500,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15100,7 +15131,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15117,12 +15149,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15415,12 +15449,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15903,12 +15939,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16117,7 +16155,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16128,7 +16167,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16138,7 +16178,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16322,12 +16363,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16472,7 +16515,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16526,7 +16570,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16934,7 +16979,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17329,7 +17375,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20188,7 +20235,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20240,7 +20288,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20294,12 +20343,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20335,7 +20386,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20355,7 +20407,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc023c-schema.json
+++ b/conf/json/cc023c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2380,7 +2388,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2568,7 +2577,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7008,7 +7018,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8783,17 +8794,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8838,12 +8852,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8870,7 +8886,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9126,7 +9143,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9284,7 +9302,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9404,12 +9423,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9644,7 +9665,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11440,7 +11462,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13537,7 +13560,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14016,7 +14040,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14032,7 +14057,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14073,22 +14099,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14475,7 +14505,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15105,7 +15136,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15122,12 +15154,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15420,12 +15454,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15908,12 +15944,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16122,7 +16160,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16133,7 +16172,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16143,7 +16183,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16327,12 +16368,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16477,7 +16520,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16531,7 +16575,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16939,7 +16984,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17334,7 +17380,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20193,7 +20240,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20245,7 +20293,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20299,12 +20348,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20340,7 +20391,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20360,7 +20412,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc025c-schema.json
+++ b/conf/json/cc025c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc028c-schema.json
+++ b/conf/json/cc028c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2369,7 +2377,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2557,7 +2566,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6997,7 +7007,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8772,17 +8783,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8827,12 +8841,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8859,7 +8875,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9115,7 +9132,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9273,7 +9291,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9393,12 +9412,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9633,7 +9654,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11429,7 +11451,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13526,7 +13549,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14005,7 +14029,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14021,7 +14046,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14062,22 +14088,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14464,7 +14494,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15094,7 +15125,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15111,12 +15143,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15409,12 +15443,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15897,12 +15933,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16111,7 +16149,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16122,7 +16161,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16132,7 +16172,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16316,12 +16357,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16466,7 +16509,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16520,7 +16564,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16928,7 +16973,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17323,7 +17369,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20182,7 +20229,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20234,7 +20282,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20288,12 +20337,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20329,7 +20380,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20349,7 +20401,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc029c-schema.json
+++ b/conf/json/cc029c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2409,7 +2417,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2597,7 +2606,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7037,7 +7047,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8812,17 +8823,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8867,12 +8881,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8899,7 +8915,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9155,7 +9172,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9313,7 +9331,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9433,12 +9452,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9673,7 +9694,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11469,7 +11491,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13566,7 +13589,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14045,7 +14069,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14061,7 +14086,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14102,22 +14128,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14504,7 +14534,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15134,7 +15165,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15151,12 +15183,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15449,12 +15483,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15937,12 +15973,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16151,7 +16189,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16162,7 +16201,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16172,7 +16212,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16356,12 +16397,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16506,7 +16549,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16560,7 +16604,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16968,7 +17013,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17363,7 +17409,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20222,7 +20269,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20274,7 +20322,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20328,12 +20377,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20369,7 +20420,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20389,7 +20441,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc035c-schema.json
+++ b/conf/json/cc035c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2380,7 +2388,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2568,7 +2577,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7008,7 +7018,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8783,17 +8794,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8838,12 +8852,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8870,7 +8886,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9126,7 +9143,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9284,7 +9302,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9404,12 +9423,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9644,7 +9665,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11440,7 +11462,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13537,7 +13560,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14016,7 +14040,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14032,7 +14057,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14073,22 +14099,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14475,7 +14505,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15105,7 +15136,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15122,12 +15154,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15420,12 +15454,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15908,12 +15944,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16122,7 +16160,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16133,7 +16172,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16143,7 +16183,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16327,12 +16368,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16477,7 +16520,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16531,7 +16575,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16939,7 +16984,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17334,7 +17380,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20193,7 +20240,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20245,7 +20293,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20299,12 +20348,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20340,7 +20391,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20360,7 +20412,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc040c-schema.json
+++ b/conf/json/cc040c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2361,7 +2369,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2549,7 +2558,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6989,7 +6999,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8764,17 +8775,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8819,12 +8833,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8851,7 +8867,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9107,7 +9124,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9265,7 +9283,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9385,12 +9404,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9625,7 +9646,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11421,7 +11443,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13518,7 +13541,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -13997,7 +14021,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14013,7 +14038,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14054,22 +14080,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14456,7 +14486,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15086,7 +15117,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15103,12 +15135,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15401,12 +15435,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15889,12 +15925,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16103,7 +16141,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16114,7 +16153,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16124,7 +16164,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16308,12 +16349,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16458,7 +16501,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16512,7 +16556,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16920,7 +16965,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17315,7 +17361,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20174,7 +20221,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20226,7 +20274,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20280,12 +20329,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20321,7 +20372,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20341,7 +20393,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc042c-schema.json
+++ b/conf/json/cc042c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2381,7 +2389,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2569,7 +2578,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7009,7 +7019,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8784,17 +8795,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8839,12 +8853,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8871,7 +8887,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9127,7 +9144,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9285,7 +9303,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9405,12 +9424,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9645,7 +9666,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11441,7 +11463,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13538,7 +13561,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14017,7 +14041,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14033,7 +14058,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14074,22 +14100,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14476,7 +14506,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15106,7 +15137,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15123,12 +15155,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15421,12 +15455,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15909,12 +15945,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16123,7 +16161,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16134,7 +16173,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16144,7 +16184,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16328,12 +16369,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16478,7 +16521,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16532,7 +16576,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16940,7 +16985,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17335,7 +17381,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20194,7 +20241,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20246,7 +20294,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20300,12 +20349,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20341,7 +20392,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20361,7 +20413,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc043c-schema.json
+++ b/conf/json/cc043c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2378,7 +2386,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2566,7 +2575,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7006,7 +7016,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8781,17 +8792,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8836,12 +8850,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8868,7 +8884,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9124,7 +9141,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9282,7 +9300,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9402,12 +9421,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9642,7 +9663,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11438,7 +11460,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13535,7 +13558,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14014,7 +14038,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14030,7 +14055,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14071,22 +14097,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14473,7 +14503,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15103,7 +15134,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15120,12 +15152,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15418,12 +15452,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15906,12 +15942,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16120,7 +16158,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16131,7 +16170,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16141,7 +16181,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16325,12 +16366,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16475,7 +16518,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16529,7 +16573,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16937,7 +16982,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17332,7 +17378,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20191,7 +20238,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20243,7 +20291,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20297,12 +20346,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20338,7 +20389,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20358,7 +20410,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc044c-schema.json
+++ b/conf/json/cc044c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc045c-schema.json
+++ b/conf/json/cc045c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc048c-schema.json
+++ b/conf/json/cc048c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2377,7 +2385,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2565,7 +2574,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7005,7 +7015,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8780,17 +8791,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8835,12 +8849,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8867,7 +8883,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9123,7 +9140,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9281,7 +9299,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9401,12 +9420,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9641,7 +9662,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11437,7 +11459,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13534,7 +13557,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14013,7 +14037,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14029,7 +14054,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14070,22 +14096,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14472,7 +14502,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15102,7 +15133,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15119,12 +15151,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15417,12 +15451,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15905,12 +15941,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16119,7 +16157,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16130,7 +16169,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16140,7 +16180,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16324,12 +16365,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16474,7 +16517,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16528,7 +16572,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16936,7 +16981,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17331,7 +17377,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20190,7 +20237,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20242,7 +20290,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20296,12 +20345,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20337,7 +20388,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20357,7 +20409,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc051c-schema.json
+++ b/conf/json/cc051c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc054c-schema.json
+++ b/conf/json/cc054c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2365,7 +2373,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2553,7 +2562,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6993,7 +7003,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8768,17 +8779,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8823,12 +8837,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8855,7 +8871,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9111,7 +9128,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9269,7 +9287,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9389,12 +9408,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9629,7 +9650,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11425,7 +11447,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13522,7 +13545,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14001,7 +14025,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14017,7 +14042,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14058,22 +14084,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14460,7 +14490,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15090,7 +15121,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15107,12 +15139,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15405,12 +15439,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15893,12 +15929,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16107,7 +16145,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16118,7 +16157,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16128,7 +16168,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16312,12 +16353,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16462,7 +16505,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16516,7 +16560,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16924,7 +16969,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17319,7 +17365,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20178,7 +20225,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20230,7 +20278,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20284,12 +20333,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20325,7 +20376,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20345,7 +20397,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc055c-schema.json
+++ b/conf/json/cc055c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2377,7 +2385,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2565,7 +2574,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7005,7 +7015,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8780,17 +8791,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8835,12 +8849,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8867,7 +8883,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9123,7 +9140,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9281,7 +9299,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9401,12 +9420,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9641,7 +9662,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11437,7 +11459,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13534,7 +13557,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14013,7 +14037,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14029,7 +14054,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14070,22 +14096,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14472,7 +14502,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15102,7 +15133,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15119,12 +15151,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15417,12 +15451,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15905,12 +15941,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16119,7 +16157,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16130,7 +16169,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16140,7 +16180,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16324,12 +16365,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16474,7 +16517,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16528,7 +16572,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16936,7 +16981,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17331,7 +17377,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20190,7 +20237,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20242,7 +20290,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20296,12 +20345,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20337,7 +20388,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20357,7 +20409,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc056c-schema.json
+++ b/conf/json/cc056c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2378,7 +2386,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2566,7 +2575,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7006,7 +7016,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8781,17 +8792,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8836,12 +8850,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8868,7 +8884,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9124,7 +9141,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9282,7 +9300,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9402,12 +9421,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9642,7 +9663,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11438,7 +11460,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13535,7 +13558,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14014,7 +14038,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14030,7 +14055,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14071,22 +14097,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14473,7 +14503,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15103,7 +15134,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15120,12 +15152,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15418,12 +15452,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15906,12 +15942,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16120,7 +16158,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16131,7 +16170,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16141,7 +16181,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16325,12 +16366,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16475,7 +16518,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16529,7 +16573,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16937,7 +16982,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17332,7 +17378,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20191,7 +20238,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20243,7 +20291,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20297,12 +20346,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20338,7 +20389,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20358,7 +20410,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc057c-schema.json
+++ b/conf/json/cc057c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2375,7 +2383,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2563,7 +2572,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7003,7 +7013,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8778,17 +8789,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8833,12 +8847,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8865,7 +8881,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9121,7 +9138,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9279,7 +9297,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9399,12 +9418,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9639,7 +9660,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11435,7 +11457,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13532,7 +13555,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14011,7 +14035,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14027,7 +14052,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14068,22 +14094,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14470,7 +14500,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15100,7 +15131,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15117,12 +15149,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15415,12 +15449,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15903,12 +15939,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16117,7 +16155,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16128,7 +16167,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16138,7 +16178,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16322,12 +16363,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16472,7 +16515,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16526,7 +16570,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16934,7 +16979,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17329,7 +17375,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20188,7 +20235,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20240,7 +20288,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20294,12 +20343,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20335,7 +20386,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20355,7 +20407,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc060c-schema.json
+++ b/conf/json/cc060c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2384,7 +2392,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2572,7 +2581,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7012,7 +7022,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8787,17 +8798,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8842,12 +8856,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8874,7 +8890,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9130,7 +9147,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9288,7 +9306,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9408,12 +9427,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9648,7 +9669,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11444,7 +11466,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13541,7 +13564,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14020,7 +14044,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14036,7 +14061,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14077,22 +14103,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14479,7 +14509,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15109,7 +15140,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15126,12 +15158,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15424,12 +15458,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15912,12 +15948,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16126,7 +16164,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16137,7 +16176,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16147,7 +16187,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16331,12 +16372,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16481,7 +16524,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16535,7 +16579,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16943,7 +16988,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17338,7 +17384,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20197,7 +20244,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20249,7 +20297,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20303,12 +20352,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20344,7 +20395,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20364,7 +20416,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc140c-schema.json
+++ b/conf/json/cc140c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2373,7 +2381,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2561,7 +2570,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7001,7 +7011,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8776,17 +8787,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8831,12 +8845,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8863,7 +8879,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9119,7 +9136,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9277,7 +9295,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9397,12 +9416,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9637,7 +9658,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11433,7 +11455,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13530,7 +13553,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14009,7 +14033,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14025,7 +14050,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14066,22 +14092,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14468,7 +14498,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15098,7 +15129,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15115,12 +15147,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15413,12 +15447,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15901,12 +15937,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16115,7 +16153,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16126,7 +16165,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16136,7 +16176,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16320,12 +16361,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16470,7 +16513,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16524,7 +16568,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16932,7 +16977,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17327,7 +17373,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20186,7 +20233,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20238,7 +20286,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20292,12 +20341,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20333,7 +20384,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20353,7 +20405,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc141c-schema.json
+++ b/conf/json/cc141c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2378,7 +2386,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2566,7 +2575,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7006,7 +7016,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8781,17 +8792,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8836,12 +8850,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8868,7 +8884,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9124,7 +9141,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9282,7 +9300,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9402,12 +9421,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9642,7 +9663,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11438,7 +11460,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13535,7 +13558,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14014,7 +14038,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14030,7 +14055,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14071,22 +14097,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14473,7 +14503,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15103,7 +15134,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15120,12 +15152,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15418,12 +15452,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15906,12 +15942,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16120,7 +16158,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16131,7 +16170,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16141,7 +16181,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16325,12 +16366,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16475,7 +16518,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16529,7 +16573,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16937,7 +16982,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17332,7 +17378,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20191,7 +20238,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20243,7 +20291,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20297,12 +20346,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20338,7 +20389,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20358,7 +20410,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc170c-schema.json
+++ b/conf/json/cc170c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc182c-schema.json
+++ b/conf/json/cc182c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2373,7 +2381,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2561,7 +2570,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7001,7 +7011,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8776,17 +8787,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8831,12 +8845,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8863,7 +8879,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9119,7 +9136,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9277,7 +9295,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9397,12 +9416,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9637,7 +9658,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11433,7 +11455,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13530,7 +13553,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14009,7 +14033,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14025,7 +14050,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14066,22 +14092,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14468,7 +14498,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15098,7 +15129,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15115,12 +15147,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15413,12 +15447,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15901,12 +15937,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16115,7 +16153,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16126,7 +16165,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16136,7 +16176,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16320,12 +16361,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16470,7 +16513,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16524,7 +16568,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16932,7 +16977,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17327,7 +17373,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20186,7 +20233,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20238,7 +20286,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20292,12 +20341,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20333,7 +20384,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20353,7 +20405,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc190c-schema.json
+++ b/conf/json/cc190c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2372,7 +2380,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2560,7 +2569,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7000,7 +7010,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8775,17 +8786,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8830,12 +8844,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8862,7 +8878,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9118,7 +9135,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9276,7 +9294,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9396,12 +9415,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9636,7 +9657,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11432,7 +11454,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13529,7 +13552,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14008,7 +14032,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14024,7 +14049,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14065,22 +14091,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14467,7 +14497,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15097,7 +15128,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15114,12 +15146,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15412,12 +15446,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15900,12 +15936,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16114,7 +16152,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16125,7 +16164,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16135,7 +16175,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16319,12 +16360,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16469,7 +16512,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16523,7 +16567,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16931,7 +16976,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17326,7 +17372,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20185,7 +20232,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20237,7 +20285,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20291,12 +20340,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20332,7 +20383,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20352,7 +20404,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc191c-schema.json
+++ b/conf/json/cc191c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2373,7 +2381,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2561,7 +2570,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7001,7 +7011,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8776,17 +8787,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8831,12 +8845,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8863,7 +8879,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9119,7 +9136,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9277,7 +9295,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9397,12 +9416,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9637,7 +9658,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11433,7 +11455,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13530,7 +13553,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14009,7 +14033,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14025,7 +14050,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14066,22 +14092,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14468,7 +14498,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15098,7 +15129,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15115,12 +15147,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15413,12 +15447,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15901,12 +15937,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16115,7 +16153,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16126,7 +16165,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16136,7 +16176,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16320,12 +16361,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16470,7 +16513,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16524,7 +16568,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16932,7 +16977,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17327,7 +17373,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20186,7 +20233,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20238,7 +20286,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20292,12 +20341,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20333,7 +20384,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20353,7 +20405,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc228c-schema.json
+++ b/conf/json/cc228c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2373,7 +2381,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2561,7 +2570,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -7001,7 +7011,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8776,17 +8787,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8831,12 +8845,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8863,7 +8879,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9119,7 +9136,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9277,7 +9295,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9397,12 +9416,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9637,7 +9658,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11433,7 +11455,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13530,7 +13553,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14009,7 +14033,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14025,7 +14050,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14066,22 +14092,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14468,7 +14498,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15098,7 +15129,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15115,12 +15147,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15413,12 +15447,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15901,12 +15937,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16115,7 +16153,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16126,7 +16165,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16136,7 +16176,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16320,12 +16361,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16470,7 +16513,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16524,7 +16568,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16932,7 +16977,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17327,7 +17373,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20186,7 +20233,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20238,7 +20286,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20292,12 +20341,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20333,7 +20384,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20353,7 +20405,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc906c-schema.json
+++ b/conf/json/cc906c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2369,7 +2377,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2557,7 +2566,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6997,7 +7007,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8772,17 +8783,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8827,12 +8841,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8859,7 +8875,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9115,7 +9132,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9273,7 +9291,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9393,12 +9412,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9633,7 +9654,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11429,7 +11451,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13526,7 +13549,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14005,7 +14029,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14021,7 +14046,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14062,22 +14088,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14464,7 +14494,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15094,7 +15125,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15111,12 +15143,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15409,12 +15443,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15897,12 +15933,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16111,7 +16149,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16122,7 +16161,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16132,7 +16172,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16316,12 +16357,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16466,7 +16509,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16520,7 +16564,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16928,7 +16973,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17323,7 +17369,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20182,7 +20229,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20234,7 +20282,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20288,12 +20337,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20329,7 +20380,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20349,7 +20401,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc917c-schema.json
+++ b/conf/json/cc917c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2368,7 +2376,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2556,7 +2565,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6996,7 +7006,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8771,17 +8782,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8826,12 +8840,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8858,7 +8874,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9114,7 +9131,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9272,7 +9290,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9392,12 +9411,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9632,7 +9653,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11428,7 +11450,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13525,7 +13548,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14004,7 +14028,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14020,7 +14045,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14061,22 +14087,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14463,7 +14493,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15093,7 +15124,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15110,12 +15142,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15408,12 +15442,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15896,12 +15932,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16110,7 +16148,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16121,7 +16160,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16131,7 +16171,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16315,12 +16356,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16465,7 +16508,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16519,7 +16563,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16927,7 +16972,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17322,7 +17368,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20181,7 +20228,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20233,7 +20281,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20287,12 +20336,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20328,7 +20379,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20348,7 +20400,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/cc928c-schema.json
+++ b/conf/json/cc928c-schema.json
@@ -180,7 +180,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2080,17 +2081,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2112,22 +2116,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2369,7 +2377,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2557,7 +2566,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6997,7 +7007,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8772,17 +8783,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8827,12 +8841,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8859,7 +8875,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9115,7 +9132,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9273,7 +9291,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9393,12 +9412,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9633,7 +9654,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11429,7 +11451,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13526,7 +13549,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -14005,7 +14029,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -14021,7 +14046,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -14062,22 +14088,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14464,7 +14494,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15094,7 +15125,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15111,12 +15143,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15409,12 +15443,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15897,12 +15933,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16111,7 +16149,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16122,7 +16161,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16132,7 +16172,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16316,12 +16357,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16466,7 +16509,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16520,7 +16564,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16928,7 +16973,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17323,7 +17369,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20182,7 +20229,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20234,7 +20282,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20288,12 +20337,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20329,7 +20380,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20349,7 +20401,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/ctypes-schema.json
+++ b/conf/json/ctypes-schema.json
@@ -177,7 +177,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -2077,17 +2078,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -2109,22 +2113,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -2306,7 +2314,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -2494,7 +2503,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -6934,7 +6944,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlResultType01": {
       "additionalProperties": false,
@@ -8705,17 +8716,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -8760,12 +8774,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -8792,7 +8808,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -9048,7 +9065,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -9206,7 +9224,8 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EndorsementType01": {
       "additionalProperties": false,
@@ -9326,12 +9345,14 @@
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryType01": {
       "additionalProperties": false,
@@ -9566,7 +9587,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -11362,7 +11384,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -13459,7 +13482,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:IncidentType01": {
       "additionalProperties": false,
@@ -13938,7 +13962,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -13954,7 +13979,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -13995,22 +14021,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -14397,7 +14427,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -15105,7 +15136,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -15122,12 +15154,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -15421,7 +15455,8 @@
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PreviousDocumentType01": {
       "additionalProperties": false,
@@ -15904,12 +15939,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -16118,7 +16155,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -16129,7 +16167,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -16139,7 +16178,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -16323,12 +16363,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -16473,7 +16515,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ResponseInformationType": {
       "additionalProperties": false,
@@ -16527,7 +16570,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisIdentificationType": {
       "additionalProperties": false,
@@ -16935,7 +16979,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -17330,7 +17375,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -20189,7 +20235,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -20241,7 +20288,8 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UsageType": {
       "additionalProperties": false,
@@ -20295,12 +20343,14 @@
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityLimitationType": {
       "additionalProperties": false,
@@ -20336,7 +20386,8 @@
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -20356,7 +20407,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XMLErrorType": {
       "additionalProperties": false,

--- a/conf/json/htypes-schema.json
+++ b/conf/json/htypes-schema.json
@@ -134,7 +134,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -572,17 +573,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -604,22 +608,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -669,7 +677,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -743,7 +752,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -839,7 +849,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlledByContentType01": {
       "description": "Used by 1/91 messages: CC017C",
@@ -1000,17 +1011,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -1055,12 +1069,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -1087,7 +1103,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -1121,7 +1138,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -1198,17 +1216,20 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ErrorCodeContentType": {
       "description": "Used by 7/91 messages: CC022C, CC056C, CC057C, CC906C, CC917C, CD906C, CD917C",
@@ -1248,7 +1269,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -1373,7 +1395,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -1462,7 +1485,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:InformationAvailableFromTraderContentType": {
       "description": "Used by 1/91 messages: CD144C",
@@ -1487,7 +1511,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -1503,7 +1528,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -1544,22 +1570,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -1576,7 +1606,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -2088,7 +2119,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -2105,12 +2137,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -2155,12 +2189,14 @@
     },
     "n1:PreparationDateAndTimeContentType": {
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2})$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:QualifierOfIdentificationContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -2186,12 +2222,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -2268,7 +2306,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -2279,7 +2318,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -2289,7 +2329,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -2310,12 +2351,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -2330,7 +2373,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RestrictedUseForSuspendedGoodsContentType": {
       "description": "Used by 1/91 messages: CC037C",
@@ -2350,7 +2394,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisResultCode": {
       "anyOf": [
@@ -2421,7 +2466,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -2500,7 +2546,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -2667,7 +2714,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -2678,22 +2726,26 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -2713,7 +2765,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:XmlErrorCodes": {
       "description": "Defines the codes to be used for reporting errors on XML messages. The values of this codelist are also available and updated in CS/RD2.",

--- a/conf/json/stypes-schema.json
+++ b/conf/json/stypes-schema.json
@@ -27,7 +27,8 @@
     "n1:AcceptanceDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AccessCodeContentType01": {
       "description": "Used by 3/91 messages: CC029C, CD200C, CD203C",
@@ -448,17 +449,20 @@
     "n1:AmendmentAcceptanceDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC004C, CC190C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC022C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC004C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AmendmentTypeFlagContentType": {
       "description": "Used by 1/91 messages: CC013C",
@@ -480,22 +484,26 @@
     "n1:ArrivalDateAndTimeActualContentType": {
       "description": "Used by 3/91 messages: CD006C, CD024C, CD209C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalDateAndTimeEstimatedContentType": {
       "description": "Used by 11/91 messages: CC013C, CC015C, CC017C, CC029C, CD001C, CD003C, CD038C, CD050C, CD115C, CD160C, CD165C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ArrivalNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC007C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:AuthorisationNumberContentType01": {
       "description": "Used by 2/91 messages: CC029C, CC190C",
@@ -545,7 +553,8 @@
     "n1:CancelEnquiryNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CD059C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:CancelEnquiryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CD059C",
@@ -619,7 +628,8 @@
     "n1:CollectionDateContentType": {
       "description": "Used by 1/91 messages: CD152C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:CombinedNomenclatureCodeContentType01": {
       "description": "Used by 15/91 messages: CC025C, CC029C, CC043C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
@@ -715,7 +725,8 @@
     "n1:ControlNotificationDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC060C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ControlledByContentType01": {
       "description": "Used by 1/91 messages: CC017C",
@@ -829,17 +840,20 @@
     "n1:DateContentType": {
       "description": "Used by 18/91 messages: CC007C, CC017C, CC029C, CC042C, CC043C, CC182C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD142C, CD160C, CD165C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DateTimeType": {
       "description": "The date is in the Common Era (minus sign in years is not permitted) and time zone although not included UTC is implied",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DateType": {
       "description": "Calendar dates are represented yyyy-mm-dd format, following ISO 8601. This is a W3C XML Schema date type, but without the optional timezone data.",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DayInTheMonthType": {
       "description": "Day in the Month (format:\n\t\t\t\tDD)",
@@ -884,12 +898,14 @@
     "n1:DecisionDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC009C, CC014C, CD010C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationAcceptanceDateContentType": {
       "description": "Used by 17/91 messages: CC023C, CC028C, CC029C, CC035C, CC043C, CC055C, CC190C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD200C, CD203C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DeclarationGoodsItemNumberContentType01": {
       "description": "Used by 22/91 messages: CC007C, CC013C, CC015C, CC017C, CC025C, CC029C, CC043C, CC044C, CC170C, CC182C, CC190C, CD001C, CD003C, CD012C, CD018C, CD038C, CD050C, CD115C, CD160C, CD165C, CD180C, CD181C",
@@ -916,7 +932,8 @@
     "n1:DeclarationSubmissionDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC051C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:DeclarationTypeContentType01": {
       "description": "Used by 1/91 messages: CC042C",
@@ -950,7 +967,8 @@
     "n1:DiscrepanciesNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC019C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:DiscrepanciesNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC019C",
@@ -1027,17 +1045,20 @@
     "n1:EndDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:EnquiryRequestDateContentType": {
       "description": "Used by 2/91 messages: CD144C, CD145C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:EnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ErrorCodeContentType": {
       "description": "Used by 7/91 messages: CC022C, CC056C, CC057C, CC906C, CC917C, CD906C, CD917C",
@@ -1077,7 +1098,8 @@
     "n1:ExpiryDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ExplanationContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
@@ -1194,7 +1216,8 @@
     "n1:GuarantorNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC023C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:GuarantorNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC023C",
@@ -1283,7 +1306,8 @@
     "n1:IncidentNotificationDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CC182C, CD180C, CD181C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:InformationAvailableFromTraderContentType": {
       "description": "Used by 1/91 messages: CD144C",
@@ -1308,7 +1332,8 @@
     "n1:InvalidityDateContentType": {
       "description": "Used by 4/91 messages: CC225C, CC228C, CC229C, CC231C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:InvalidityReasonCodeContentType": {
       "description": "Used by 3/91 messages: CC037C, CC225C, CC231C",
@@ -1324,7 +1349,8 @@
     "n1:IssueDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:JustificationContentType01": {
       "description": "Used by 1/91 messages: CC009C",
@@ -1365,22 +1391,26 @@
     "n1:LiabilityLiberationDateContentType": {
       "description": "Used by 2/91 messages: CC037C, CC228C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitDateContentType": {
       "description": "Used by 3/91 messages: CC013C, CC015C, CC170C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForResponseDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LimitForTheEnquiryResponseDateContentType": {
       "description": "Used by 1/91 messages: CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LocationContentType01": {
       "description": "Used by 4/91 messages: CC013C, CC015C, CC017C, CC170C",
@@ -1397,7 +1427,8 @@
     "n1:LockDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:LongitudeContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -1774,7 +1805,8 @@
     "n1:PassageDateContentType": {
       "description": "Used by 2/91 messages: CD118C, CD168C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PercentageOfReferenceAmountContentType01": {
       "description": "Used by 1/91 messages: CC037C",
@@ -1791,12 +1823,14 @@
     "n1:PeriodFromDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PeriodToDateContentType": {
       "description": "Used by 2/91 messages: CC034C, CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:PhoneNumberContentType01": {
       "description": "Used by 11/91 messages: CC029C, CC037C, CC051C, CC190C, CD142C, CD143C, CD144C, CD145C, CD150C, CD151C, CD152C",
@@ -1842,7 +1876,8 @@
     "n1:PresentationOfTheGoodsDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC013C, CC015C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:QualifierOfIdentificationContentType": {
       "description": "Used by 14/91 messages: CC007C, CC013C, CC015C, CC029C, CC043C, CC170C, CC182C, CC190C, CD003C, CD038C, CD115C, CD165C, CD180C, CD181C",
@@ -1868,12 +1903,14 @@
     "n1:RecoveryCommunicationDateContentType": {
       "description": "Used by 4/91 messages: CC048C, CD063C, CD150C, CD151C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationDateContentType": {
       "description": "Used by 1/91 messages: CC035C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RecoveryNotificationTextContentType": {
       "description": "Used by 1/91 messages: CC035C",
@@ -1950,7 +1987,8 @@
     "n1:RejectionDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RejectionReasonContentType": {
       "description": "Used by 2/91 messages: CC056C, CC057C",
@@ -1961,7 +1999,8 @@
     "n1:ReleaseDateContentType": {
       "description": "Used by 12/91 messages: CC025C, CC029C, CC037C, CD001C, CD003C, CD012C, CD038C, CD050C, CD115C, CD160C, CD165C, CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ReleaseIndicatorContentType": {
       "description": "Used by 1/91 messages: CC025C",
@@ -1971,7 +2010,8 @@
     "n1:ReleaseRequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:ReleaseRequestedContentType": {
       "description": "Used by 2/91 messages: CC017C, CC054C",
@@ -1992,12 +2032,14 @@
     "n1:RequestDateAndTimeContentType": {
       "description": "Used by 2/91 messages: CC009C, CC014C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RequestOnNonArrivedMovementDateContentType": {
       "description": "Used by 1/91 messages: CC140C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RequestRejectionReasonCodeContentType": {
       "description": "Used by 4/91 messages: CD003C, CD038C, CD115C, CD165C",
@@ -2012,7 +2054,8 @@
     "n1:ResponseDateAndTimeContentType": {
       "description": "Used by 1/91 messages: CC191C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:RestrictedUseForSuspendedGoodsContentType": {
       "description": "Used by 1/91 messages: CC037C",
@@ -2032,7 +2075,8 @@
     "n1:ReturnCopyReturnedDateContentType": {
       "description": "Used by 1/91 messages: CD143C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:RiskAnalysisResultCode": {
       "anyOf": [
@@ -2103,7 +2147,8 @@
     "n1:StartDateAndTimeContentType": {
       "description": "Used by 3/91 messages: CD070C, CD071C, CD971C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}T[\\d]{2,2}\\:[\\d]{2,2}\\:[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "n1:StateOfSealsContentType": {
       "description": "Used by 2/91 messages: CC044C, CD018C",
@@ -2173,7 +2218,8 @@
     "n1:TC11DeliveryDateContentType": {
       "description": "Used by 2/91 messages: CC141C, CD142C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:TINNewType": {
       "description": "EORI or TCUI Number (format: an..17)",
@@ -2340,7 +2386,8 @@
     "n1:UnloadingDateContentType": {
       "description": "Used by 1/91 messages: CC044C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:UnloadingRemarkContentType": {
       "description": "Used by 1/91 messages: CC044C",
@@ -2351,22 +2398,26 @@
     "n1:UsageCancellationDateContentType": {
       "description": "Used by 1/91 messages: CD204C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityDateContentType": {
       "description": "Used by 1/91 messages: CC225C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityEndDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:ValidityStartDateContentType": {
       "description": "Used by 1/91 messages: CC037C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:VoucherAmountContentType": {
       "description": "Used by 2/91 messages: CC037C, CC224C",
@@ -2386,7 +2437,8 @@
     "n1:WriteOffDateContentType": {
       "description": "Used by 2/91 messages: CC045C, CD049C",
       "pattern": "^([\\d]{4,4}\\-[\\d]{2,2}\\-[\\d]{2,2}(\\.[\\d]+)?)$",
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "n1:YearContentType": {
       "description": "Used by 2/91 messages: CD411D, CD903D",

--- a/conf/python/json_processor.py
+++ b/conf/python/json_processor.py
@@ -92,6 +92,13 @@ def createHook(code=None):
             if child in dct:
                 values_to_correct[child](dct[child])
 
+        # date time format addition
+        if 'pattern' in dct and 'type' in dct and 'format' not in dct:
+            if r'[\d]{4,4}\-[\d]{2,2}\-[\d]{2,2}T[\d]{2,2}\:[\d]{2,2}\:[\d]{2,2}' in dct['pattern']:
+                dct['format'] = 'date-time'
+            elif r'([\d]{4,4}\-[\d]{2,2}\-[\d]{2,2}(\.[\d]+)?' in dct['pattern']:
+                dct['format'] = 'date'
+
         if code is not None and 'n1:MessageTypes' in dct:
             properties = dct['n1:MessageTypes']
             properties['enum'] = [code]

--- a/test/uk/gov/hmrc/transitmovementsvalidator/data/cc013c-invalid-date.json
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/data/cc013c-invalid-date.json
@@ -1,0 +1,457 @@
+{
+  "n1:CC013C": {
+    "preparationDateAndTime": "2007-10-26T07:36:28",
+    "TransitOperation": {
+      "LRN": "string",
+      "MRN": "29GMFMHYWWCFCWRVJ3",
+      "declarationType": "token",
+      "additionalDeclarationType": "a",
+      "TIRCarnetNumber": "123456",
+      "presentationOfTheGoodsDateAndTime": "2014-06-09T16:15:04",
+      "security": "0",
+      "reducedDatasetIndicator": "1",
+      "specificCircumstanceIndicator": "abc",
+      "communicationLanguageAtDeparture": "GB",
+      "bindingItinerary": "1",
+      "amendmentTypeFlag": "0",
+      "limitDate": "2017-13-15"
+    },
+    "CustomsOfficeOfDeparture": {
+      "referenceNumber": "GB123456"
+    },
+    "Consignment": {
+      "countryOfDispatch": "GB",
+      "countryOfDestination": "XI",
+      "containerIndicator": "1",
+      "inlandModeOfTransport": "0",
+      "modeOfTransportAtTheBorder": "1",
+      "grossMass": 1000,
+      "referenceNumberUCR": "string",
+      "Carrier": {
+        "identificationNumber": "AZ!-",
+        "ContactPerson": {
+          "name": "string",
+          "phoneNumber": "token",
+          "eMailAddress": "string"
+        }
+      },
+      "Consignor": {
+        "identificationNumber": "string",
+        "name": "string",
+        "Address": {
+          "streetAndNumber": "string",
+          "postcode": "string",
+          "city": "string",
+          "country": "GB"
+        },
+        "ContactPerson": {
+          "name": "string",
+          "phoneNumber": "token",
+          "eMailAddress": "string"
+        }
+      },
+      "Consignee": {
+        "identificationNumber": "string",
+        "name": "string",
+        "Address": {
+          "streetAndNumber": "string",
+          "postcode": "string",
+          "city": "string",
+          "country": "GB"
+        }
+      },
+      "AdditionalSupplyChainActor": [
+        {
+          "sequenceNumber": "123",
+          "role": "abc",
+          "identificationNumber": "AB!"
+        }
+      ],
+      "TransportEquipment": [
+        {
+          "sequenceNumber": "123",
+          "containerIdentificationNumber": "string",
+          "numberOfSeals": 100,
+          "Seal": [
+            {
+              "sequenceNumber": "123",
+              "identifier": "string"
+            }
+          ],
+          "GoodsReference": [
+            {
+              "sequenceNumber": "123",
+              "declarationGoodsItemNumber": 100
+            }
+          ]
+        }
+      ],
+      "LocationOfGoods": {
+        "typeOfLocation": "a",
+        "qualifierOfIdentification": "a",
+        "authorisationNumber": "string",
+        "additionalIdentifier": "stri",
+        "UNLocode": "token",
+        "CustomsOffice": {
+          "referenceNumber": "GB123456"
+        },
+        "GNSS": {
+          "latitude": "+1.00000",
+          "longitude": "+1.00000"
+        },
+        "EconomicOperator": {
+          "identificationNumber": "string"
+        },
+        "Address": {
+          "streetAndNumber": "string",
+          "postcode": "string",
+          "city": "string",
+          "country": "GB"
+        },
+        "PostcodeAddress": {
+          "houseNumber": "string",
+          "postcode": "string",
+          "country": "GB"
+        },
+        "ContactPerson": {
+          "name": "string",
+          "phoneNumber": "token",
+          "eMailAddress": "string"
+        }
+      },
+      "DepartureTransportMeans": [
+        {
+          "sequenceNumber": "123",
+          "typeOfIdentification": "12",
+          "identificationNumber": "string",
+          "nationality": "XI"
+        }
+      ],
+      "CountryOfRoutingOfConsignment": [
+        {
+          "sequenceNumber": "123",
+          "country": "GB"
+        }
+      ],
+      "ActiveBorderTransportMeans": [
+        {
+          "sequenceNumber": "123",
+          "customsOfficeAtBorderReferenceNumber": "abcdabcd",
+          "typeOfIdentification": "12",
+          "identificationNumber": "string",
+          "nationality": "GB",
+          "conveyanceReferenceNumber": "string"
+        }
+      ],
+      "PlaceOfLoading": {
+        "UNLocode": "token",
+        "country": "GB",
+        "location": "string"
+      },
+      "PlaceOfUnloading": {
+        "UNLocode": "token",
+        "country": "GB",
+        "location": "string"
+      },
+      "PreviousDocument": [
+        {
+          "sequenceNumber": "123",
+          "type": "abcd",
+          "referenceNumber": "string",
+          "complementOfInformation": "string"
+        }
+      ],
+      "SupportingDocument": [
+        {
+          "sequenceNumber": "123",
+          "type": "abcd",
+          "referenceNumber": "string",
+          "documentLineItemNumber": 100,
+          "complementOfInformation": "string"
+        }
+      ],
+      "TransportDocument": [
+        {
+          "sequenceNumber": "123",
+          "type": "abcd",
+          "referenceNumber": "string"
+        }
+      ],
+      "AdditionalReference": [
+        {
+          "sequenceNumber": "123",
+          "type": "abcd",
+          "referenceNumber": "string"
+        }
+      ],
+      "AdditionalInformation": [
+        {
+          "sequenceNumber": "123",
+          "code": "token",
+          "text": "string"
+        }
+      ],
+      "TransportCharges": {
+        "methodOfPayment": "A"
+      },
+      "HouseConsignment": [
+        {
+          "sequenceNumber": "123",
+          "countryOfDispatch": "st",
+          "grossMass": 1000,
+          "referenceNumberUCR": "string",
+          "Consignor": {
+            "identificationNumber": "string",
+            "name": "string",
+            "Address": {
+              "streetAndNumber": "string",
+              "postcode": "string",
+              "city": "string",
+              "country": "GB"
+            },
+            "ContactPerson": {
+              "name": "string",
+              "phoneNumber": "token",
+              "eMailAddress": "string"
+            }
+          },
+          "Consignee": {
+            "identificationNumber": "string",
+            "name": "string",
+            "Address": {
+              "streetAndNumber": "string",
+              "postcode": "string",
+              "city": "string",
+              "country": "GB"
+            }
+          },
+          "AdditionalSupplyChainActor": [
+            {
+              "sequenceNumber": "123",
+              "role": "abc",
+              "identificationNumber": "AV!---"
+            }
+          ],
+          "DepartureTransportMeans": [
+            {
+              "sequenceNumber": "123",
+              "typeOfIdentification": "12",
+              "identificationNumber": "string",
+              "nationality": "XI"
+            }
+          ],
+          "PreviousDocument": [
+            {
+              "sequenceNumber": "123",
+              "type": "abcd",
+              "referenceNumber": "string",
+              "complementOfInformation": "string"
+            }
+          ],
+          "SupportingDocument": [
+            {
+              "sequenceNumber": "123",
+              "type": "abcd",
+              "referenceNumber": "string",
+              "documentLineItemNumber": 100,
+              "complementOfInformation": "string"
+            }
+          ],
+          "TransportDocument": [
+            {
+              "sequenceNumber": "123",
+              "type": "abcd",
+              "referenceNumber": "string"
+            }
+          ],
+          "AdditionalReference": [
+            {
+              "sequenceNumber": "123",
+              "type": "abcd",
+              "referenceNumber": "string"
+            }
+          ],
+          "AdditionalInformation": [
+            {
+              "sequenceNumber": "123",
+              "code": "token",
+              "text": "string"
+            }
+          ],
+          "TransportCharges": {
+            "methodOfPayment": "A"
+          },
+          "ConsignmentItem": [
+            {
+              "goodsItemNumber": "123",
+              "declarationGoodsItemNumber": 100,
+              "declarationType": "token",
+              "countryOfDispatch": "GB",
+              "countryOfDestination": "XI",
+              "referenceNumberUCR": "string",
+              "Consignee": {
+                "identificationNumber": "string",
+                "name": "string",
+                "Address": {
+                  "streetAndNumber": "string",
+                  "postcode": "string",
+                  "city": "string",
+                  "country": "GB"
+                }
+              },
+              "AdditionalSupplyChainActor": [
+                {
+                  "sequenceNumber": "123",
+                  "role": "abc",
+                  "identificationNumber": "AB!--!"
+                }
+              ],
+              "Commodity": {
+                "descriptionOfGoods": "string",
+                "cusCode": "abcdefghi",
+                "CommodityCode": {
+                  "harmonizedSystemSubHeadingCode": "tokent",
+                  "combinedNomenclatureCode": "st"
+                },
+                "DangerousGoods": [
+                  {
+                    "sequenceNumber": "123",
+                    "UNNumber": "abcd"
+                  }
+                ],
+                "GoodsMeasure": {
+                  "grossMass": 1000,
+                  "netMass": 1000,
+                  "supplementaryUnits": 1000
+                }
+              },
+              "Packaging": [
+                {
+                  "sequenceNumber": "123",
+                  "typeOfPackages": "ab",
+                  "numberOfPackages": 100,
+                  "shippingMarks": "string"
+                }
+              ],
+              "PreviousDocument": [
+                {
+                  "sequenceNumber": "123",
+                  "type": "abcd",
+                  "referenceNumber": "string",
+                  "goodsItemNumber": 100,
+                  "typeOfPackages": "ab",
+                  "numberOfPackages": 100,
+                  "measurementUnitAndQualifier": "a",
+                  "quantity": 1000,
+                  "complementOfInformation": "string"
+                }
+              ],
+              "SupportingDocument": [
+                {
+                  "sequenceNumber": "123",
+                  "type": "abcd",
+                  "referenceNumber": "string",
+                  "documentLineItemNumber": 100,
+                  "complementOfInformation": "string"
+                }
+              ],
+              "TransportDocument": [
+                {
+                  "sequenceNumber": "123",
+                  "type": "abcd",
+                  "referenceNumber": "string"
+                }
+              ],
+              "AdditionalReference": [
+                {
+                  "sequenceNumber": "123",
+                  "type": "abcd",
+                  "referenceNumber": "string"
+                }
+              ],
+              "AdditionalInformation": [
+                {
+                  "sequenceNumber": "123",
+                  "code": "token",
+                  "text": "string"
+                }
+              ],
+              "TransportCharges": {
+                "methodOfPayment": "A"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "CustomsOfficeOfExitForTransitDeclared": [
+      {
+        "sequenceNumber": "123",
+        "referenceNumber": "AB123456"
+      }
+    ],
+    "CustomsOfficeOfTransitDeclared": [
+      {
+        "sequenceNumber": "123",
+        "referenceNumber": "AB123456",
+        "arrivalDateAndTimeEstimated": "2013-12-21T11:32:42"
+      }
+    ],
+    "CustomsOfficeOfDestinationDeclared": {
+      "referenceNumber": "GB123456"
+    },
+    "messageType": "CC013C",
+    "@PhaseID": "NCTS5.0",
+    "correlationIdentifier": "token",
+    "Authorisation": [
+      {
+        "sequenceNumber": "123",
+        "type": "0",
+        "referenceNumber": "string"
+      }
+    ],
+    "messageRecipient": "token",
+    "HolderOfTheTransitProcedure": {
+      "identificationNumber": "string",
+      "TIRHolderIdentificationNumber": "string",
+      "name": "string",
+      "Address": {
+        "streetAndNumber": "string",
+        "postcode": "string",
+        "city": "string",
+        "country": "GB"
+      },
+      "ContactPerson": {
+        "name": "string",
+        "phoneNumber": "token",
+        "eMailAddress": "string"
+      }
+    },
+    "Representative": {
+      "identificationNumber": "string",
+      "status": "0",
+      "ContactPerson": {
+        "name": "string",
+        "phoneNumber": "token",
+        "eMailAddress": "string"
+      }
+    },
+    "messageIdentification": "token",
+    "Guarantee": [
+      {
+        "sequenceNumber": "123",
+        "guaranteeType": "B",
+        "otherGuaranteeReference": "GBP",
+        "GuaranteeReference": [
+          {
+            "sequenceNumber": "123",
+            "GRN": "ABC",
+            "accessCode": "stri",
+            "amountToBeCovered": 1000,
+            "currency": "GBP"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/uk/gov/hmrc/transitmovementsvalidator/data/cc014c-invalid-date-time.json
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/data/cc014c-invalid-date-time.json
@@ -1,0 +1,40 @@
+{
+  "n1:CC014C": {
+    "preparationDateAndTime": "2007-14-26T07:36:28",
+    "TransitOperation": {
+      "LRN": "string",
+      "MRN": "29GMFMHYWWCFCWRVJ3"
+    },
+    "CustomsOfficeOfDeparture": {
+      "referenceNumber": "GB123456"
+    },
+    "messageType": "CC014C",
+    "@PhaseID": "NCTS5.0",
+    "correlationIdentifier": "token",
+    "messageRecipient": "token",
+    "HolderOfTheTransitProcedure": {
+      "identificationNumber": "string",
+      "TIRHolderIdentificationNumber": "string",
+      "name": "string",
+      "Address": {
+        "streetAndNumber": "string",
+        "postcode": "string",
+        "city": "string",
+        "country": "GB"
+      },
+      "ContactPerson": {
+        "name": "string",
+        "phoneNumber": "token",
+        "eMailAddress": "string"
+      }
+    },
+    "Invalidation": {
+      "requestDateAndTime": "2014-06-09T16:15:04",
+      "decisionDateAndTime": "2008-11-15T16:52:58",
+      "decision": "0",
+      "initiatedByCustoms": "1",
+      "justification": "string"
+    },
+    "messageIdentification": "token"
+  }
+}

--- a/test/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateFormatSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateFormatSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsvalidator.services.jsonformats
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class DateFormatSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "matches" - {
+    "is true for a date that can be parsed" in {
+      DateFormat.matches("2022-10-25") mustBe true
+    }
+
+    "is false for a date that cannot be parsed" in {
+      DateFormat.matches("2022-14-25") mustBe false
+    }
+
+    "is false for a datetime that cannot be parsed" in {
+      DateFormat.matches("2022-14-25") mustBe false
+    }
+
+    "is false for a date that cannot be parsed due a random string" in forAll(Gen.alphaNumStr) {
+      string =>
+        DateFormat.matches(string) mustBe false
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateTimeFormatSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/services/jsonformats/DateTimeFormatSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementsvalidator.services.jsonformats
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class DateTimeFormatSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "matches" - {
+    "is true for a datetime that can be parsed" in {
+      DateTimeFormat.matches("2022-10-25T00:01:02") mustBe true
+    }
+
+    "is true for a datetime with milliseconds can be parsed" in {
+      DateTimeFormat.matches("2022-10-25T00:01:02.000") mustBe true
+    }
+
+    "is false for just a date" in {
+      DateTimeFormat.matches("2022-14-25") mustBe false
+    }
+
+    "is false for a datetime that cannot be parsed due to an incorrect date" in {
+      DateTimeFormat.matches("2022-14-25T00:01:02") mustBe false
+    }
+
+    "is false for a datetime that cannot be parsed due to an incorrect time" in {
+      DateTimeFormat.matches("2022-12-25T34:01:02") mustBe false
+    }
+
+    "is false for a datetime that cannot be parsed due a random string" in forAll(Gen.alphaNumStr) {
+      string =>
+        DateTimeFormat.matches(string) mustBe false
+    }
+  }
+
+}


### PR DESCRIPTION
* Update Python post-processing script to add formats
* Add formats to Json schema validator
* Update json schema
* Updated tests