### PR TITLE
CTCP-3714: Add response types to the validator (toggled off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 # Transit Movements Validator
-This is a microservice for an internal API to parse and validate XML payloads. 
+This is a microservice for an internal API to parse and schema validate XML and Json payloads. There are also select business rule validations.
 
-This microservice is in [Beta](https://www.gov.uk/help/beta). The signature may change.
+By default, this service will only validate request messages. To enable validation of response messages, set the configuration option `validate-request-types-only` to `false`.
 
 ## Prerequisites
 
@@ -16,14 +16,14 @@ This microservice is in [Beta](https://www.gov.uk/help/beta). The signature may 
 Run from the console using: `sbt run`
 
 ### Highlighted SBT Tasks
-Task | Description | Command
-:-------|:------------|:-----
-run | Runs the application with the default configured port | ```$ sbt run```
-test | Runs the standard unit tests | ```$ sbt test```
-it:test  | Runs the integration tests | ```$ sbt it:test ```
-dependencyCheck | Runs dependency-check against the current project. It aggregates dependencies and generates a report | ```$ sbt dependencyCheck```
-dependencyUpdates |  Shows a list of project dependencies that can be updated | ```$ sbt dependencyUpdates```
-dependencyUpdatesReport | Writes a list of project dependencies to a file | ```$ sbt dependencyUpdatesReport```
+| Task                    | Description                                                                                          | Command                             |
+|:------------------------|:-----------------------------------------------------------------------------------------------------|:------------------------------------|
+| run                     | Runs the application with the default configured port                                                | ```$ sbt run```                     |
+| test                    | Runs the standard unit tests                                                                         | ```$ sbt test```                    |
+| it:test                 | Runs the integration tests                                                                           | ```$ sbt it:test ```                |
+| dependencyCheck         | Runs dependency-check against the current project. It aggregates dependencies and generates a report | ```$ sbt dependencyCheck```         |
+| dependencyUpdates       | Shows a list of project dependencies that can be updated                                             | ```$ sbt dependencyUpdates```       |
+| dependencyUpdatesReport | Writes a list of project dependencies to a file                                                      | ```$ sbt dependencyUpdatesReport``` |
 
 ## Related API documentation
 

--- a/app/uk/gov/hmrc/transitmovementsvalidator/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/transitmovementsvalidator/config/AppConfig.scala
@@ -26,4 +26,6 @@ class AppConfig @Inject() (config: Configuration) {
   lazy val appName: String = config.get[String]("appName")
 
   lazy val enableBusinessValidationMessageRecipient: Boolean = config.get[Boolean]("business-validation.enforce-messageRecipient")
+
+  lazy val validateRequestTypesOnly: Boolean = config.getOptional[Boolean]("validate-request-types-only").getOrElse(true)
 }

--- a/app/uk/gov/hmrc/transitmovementsvalidator/controllers/MessagesController.scala
+++ b/app/uk/gov/hmrc/transitmovementsvalidator/controllers/MessagesController.scala
@@ -27,6 +27,7 @@ import play.api.libs.json.Json
 import play.api.mvc._
 import play.mvc.Http.MimeTypes
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.transitmovementsvalidator.config.AppConfig
 import uk.gov.hmrc.transitmovementsvalidator.controllers.stream.StreamingParsers
 import uk.gov.hmrc.transitmovementsvalidator.models.MessageFormat
 import uk.gov.hmrc.transitmovementsvalidator.models.MessageType
@@ -41,7 +42,8 @@ class MessagesController @Inject() (
   cc: ControllerComponents,
   xmlValidationService: XmlValidationService,
   jsonValidationService: JsonValidationService,
-  businessValidationService: BusinessValidationService
+  businessValidationService: BusinessValidationService,
+  config: AppConfig
 )(implicit
   val materializer: Materializer,
   val temporaryFileCreator: TemporaryFileCreator,
@@ -83,6 +85,8 @@ class MessagesController @Inject() (
     }
 
   private def findMessageType(messageType: String): EitherT[Future, PresentationError, MessageType] =
-    EitherT.fromEither(MessageType.find(messageType).toRight[ValidationError](ValidationError.UnknownMessageType(messageType))).asPresentation
+    EitherT
+      .fromEither(MessageType.find(messageType, config.validateRequestTypesOnly).toRight[ValidationError](ValidationError.UnknownMessageType(messageType)))
+      .asPresentation
 
 }

--- a/app/uk/gov/hmrc/transitmovementsvalidator/models/MessageType.scala
+++ b/app/uk/gov/hmrc/transitmovementsvalidator/models/MessageType.scala
@@ -21,17 +21,25 @@ sealed trait MessageType {
   def rootNode: String
   def xsdPath: String
   def jsonSchemaPath: String
+}
 
+sealed trait RequestMessageType extends MessageType {
   def routingOfficeNode: String
 }
 
-sealed abstract class DepartureMessageType(val code: String, val rootNode: String, val xsdPath: String, val jsonSchemaPath: String) extends MessageType {
+sealed trait DepartureRequestMessageType extends RequestMessageType {
   override lazy val routingOfficeNode: String = "CustomsOfficeOfDeparture"
 }
 
-sealed abstract class ArrivalMessageType(val code: String, val rootNode: String, val xsdPath: String, val jsonSchemaPath: String) extends MessageType {
+sealed trait ArrivalRequestMessageType extends RequestMessageType {
   override lazy val routingOfficeNode: String = "CustomsOfficeOfDestinationActual"
 }
+
+sealed trait ResponseMessageType extends MessageType
+
+sealed abstract class DepartureMessageType(val code: String, val rootNode: String, val xsdPath: String, val jsonSchemaPath: String) extends MessageType
+
+sealed abstract class ArrivalMessageType(val code: String, val rootNode: String, val xsdPath: String, val jsonSchemaPath: String) extends MessageType
 
 object MessageType {
 
@@ -40,18 +48,24 @@ object MessageType {
   // *******************
 
   /** E_DEC_AMD (IE013) */
-  case object DeclarationAmendment extends DepartureMessageType("IE013", "CC013C", "/xsd/cc013c.xsd", "/json/cc013c-schema.json")
+  case object DeclarationAmendment
+      extends DepartureMessageType("IE013", "CC013C", "/xsd/cc013c.xsd", "/json/cc013c-schema.json")
+      with DepartureRequestMessageType
 
   /** E_DEC_INV (IE014) */
-  case object DeclarationInvalidation extends DepartureMessageType("IE014", "CC014C", "/xsd/cc014c.xsd", "/json/cc014c-schema.json")
+  case object DeclarationInvalidation
+      extends DepartureMessageType("IE014", "CC014C", "/xsd/cc014c.xsd", "/json/cc014c-schema.json")
+      with DepartureRequestMessageType
 
   /** E_DEC_DAT (IE015) */
-  case object DeclarationData extends DepartureMessageType("IE015", "CC015C", "/xsd/cc015c.xsd", "/json/cc015c-schema.json")
+  case object DeclarationData extends DepartureMessageType("IE015", "CC015C", "/xsd/cc015c.xsd", "/json/cc015c-schema.json") with DepartureRequestMessageType
 
   /** E_PRE_NOT (IE170) */
-  case object PresentationNotificationForPreLodgedDec extends DepartureMessageType("IE170", "CC170C", "/xsd/cc170c.xsd", "/json/cc170c-schema.json")
+  case object PresentationNotificationForPreLodgedDec
+      extends DepartureMessageType("IE170", "CC170C", "/xsd/cc170c.xsd", "/json/cc170c-schema.json")
+      with DepartureRequestMessageType
 
-  val departureValues = Set(
+  val departureRequestValues: Set[MessageType] = Set(
     DeclarationAmendment,
     DeclarationInvalidation,
     DeclarationData,
@@ -63,18 +77,86 @@ object MessageType {
   // ****************
 
   /** E_ARR_NOT (IE007) */
-  case object ArrivalNotification extends ArrivalMessageType("IE007", "CC007C", "/xsd/cc007c.xsd", "/json/cc007c-schema.json")
+  case object ArrivalNotification extends ArrivalMessageType("IE007", "CC007C", "/xsd/cc007c.xsd", "/json/cc007c-schema.json") with ArrivalRequestMessageType
 
   /** E_ULD_REM (IE044) */
-  case object UnloadingRemarks extends ArrivalMessageType("IE044", "CC044C", "/xsd/cc044c.xsd", "/json/cc044c-schema.json")
+  case object UnloadingRemarks extends ArrivalMessageType("IE044", "CC044C", "/xsd/cc044c.xsd", "/json/cc044c-schema.json") with ArrivalRequestMessageType
 
-  val arrivalValues = Set(
+  val arrivalRequestValues: Set[MessageType] = Set(
     ArrivalNotification,
     UnloadingRemarks
   )
 
-  val values = arrivalValues ++ departureValues
+  // *****
+  // Departure Responses
+  // *****
 
-  def find(code: String): Option[MessageType] = values.find(_.code == code)
+  case object AmendmentAcceptance  extends DepartureMessageType("IE004", "CC004C", "/xsd/cc004c.xsd", "/json/cc004c-schema.json") with ResponseMessageType
+  case object InvalidationDecision extends DepartureMessageType("IE009", "CC009C", "/xsd/cc009c.xsd", "/json/cc009c-schema.json") with ResponseMessageType
+  case object Discrepancies        extends DepartureMessageType("IE019", "CC019C", "/xsd/cc019c.xsd", "/json/cc019c-schema.json") with ResponseMessageType
+  case object MRNAllocated         extends DepartureMessageType("IE028", "CC028C", "/xsd/cc028c.xsd", "/json/cc028c-schema.json") with ResponseMessageType
+  case object ReleaseForTransit    extends DepartureMessageType("IE029", "CC029C", "/xsd/cc029c.xsd", "/json/cc029c-schema.json") with ResponseMessageType
+  case object RecoveryNotification extends DepartureMessageType("IE035", "CC035C", "/xsd/cc035c.xsd", "/json/cc035c-schema.json") with ResponseMessageType
+  case object WriteOffNotification extends DepartureMessageType("IE045", "CC045C", "/xsd/cc045c.xsd", "/json/cc045c-schema.json") with ResponseMessageType
+  case object NoReleaseForTransit  extends DepartureMessageType("IE051", "CC051C", "/xsd/cc051c.xsd", "/json/cc051c-schema.json") with ResponseMessageType
+  case object GuaranteeNotValid    extends DepartureMessageType("IE055", "CC055C", "/xsd/cc055c.xsd", "/json/cc055c-schema.json") with ResponseMessageType
+
+  case object RejectionFromOfficeOfDeparture
+      extends DepartureMessageType("IE056", "CC056C", "/xsd/cc056c.xsd", "/json/cc056c-schema.json")
+      with ResponseMessageType
+
+  case object ControlDecisionNotification
+      extends DepartureMessageType("IE060", "CC060C", "/xsd/cc060c.xsd", "/json/cc060c-schema.json")
+      with ResponseMessageType
+
+  case object ForwardedIncidentNotificationToED
+      extends DepartureMessageType("IE182", "CC182C", "/xsd/cc182c.xsd", "/json/cc182c-schema.json")
+      with ResponseMessageType
+  case object FunctionalNack      extends DepartureMessageType("IE906", "CC906C", "/xsd/cc906c.xsd", "/json/cc906c-schema.json") with ResponseMessageType
+  case object PositiveAcknowledge extends DepartureMessageType("IE928", "CC928C", "/xsd/cc928c.xsd", "/json/cc928c-schema.json") with ResponseMessageType
+
+  val departureResponseValues: Set[MessageType] = Set(
+    AmendmentAcceptance,
+    InvalidationDecision,
+    Discrepancies,
+    MRNAllocated,
+    ReleaseForTransit,
+    RecoveryNotification,
+    WriteOffNotification,
+    NoReleaseForTransit,
+    GuaranteeNotValid,
+    RejectionFromOfficeOfDeparture,
+    ControlDecisionNotification,
+    ForwardedIncidentNotificationToED,
+    FunctionalNack,
+    PositiveAcknowledge
+  )
+
+  // ****
+  // Arrival Responses
+  // ***
+
+  case object GoodsReleaseNotification extends ArrivalMessageType("IE025", "CC025C", "/xsd/cc025c.xsd", "/json/cc025c-schema.json") with ResponseMessageType
+
+  case object UnloadingPermission extends ArrivalMessageType("IE043", "CC043C", "/xsd/cc043c.xsd", "/json/cc043c-schema.json") with ResponseMessageType
+
+  case object RejectionFromOfficeOfDestination
+      extends ArrivalMessageType("IE057", "CC057C", "/xsd/cc057c.xsd", "/json/cc057c-schema.json")
+      with ResponseMessageType
+
+  val arrivalResponseValues: Set[MessageType] = Set(
+    GoodsReleaseNotification,
+    UnloadingPermission,
+    RejectionFromOfficeOfDestination,
+    FunctionalNack,
+    PositiveAcknowledge
+  )
+
+  val requestValues  = arrivalRequestValues ++ departureRequestValues
+  val responseValues = arrivalResponseValues ++ departureResponseValues
+
+  val values: Set[MessageType] = requestValues ++ responseValues
+
+  def find(code: String, requestOnly: Boolean): Option[MessageType] = (if (requestOnly) requestValues else values).find(_.code == code)
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -120,6 +120,7 @@ jdk.xml.maxOccurLimit = 100000
 
 object-store.default-retention-period = "7-years"
 internal-auth.token = "transit-movements-validator-token"
+validate-request-types-only = true
 
 business-validation {
   enforce-messageRecipient = true

--- a/test/uk/gov/hmrc/transitmovementsvalidator/models/MessageTypeSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/models/MessageTypeSpec.scala
@@ -35,54 +35,64 @@ class MessageTypeSpec extends AnyFreeSpec with Matchers with MockitoSugar with O
       MessageType.values must contain(UnloadingRemarks)
       UnloadingRemarks.code mustEqual "IE044"
       UnloadingRemarks.rootNode mustEqual "CC044C"
-      MessageType.arrivalValues must contain(UnloadingRemarks)
+      MessageType.arrivalRequestValues must contain(UnloadingRemarks)
     }
 
     "ArrivalNotification" in {
       MessageType.values must contain(ArrivalNotification)
       ArrivalNotification.code mustEqual "IE007"
       ArrivalNotification.rootNode mustEqual "CC007C"
-      MessageType.arrivalValues must contain(ArrivalNotification)
+      MessageType.arrivalRequestValues must contain(ArrivalNotification)
     }
 
     "DeclarationAmendment" in {
       MessageType.values must contain(DeclarationAmendment)
       DeclarationAmendment.code mustEqual "IE013"
       DeclarationAmendment.rootNode mustEqual "CC013C"
-      MessageType.departureValues must contain(DeclarationAmendment)
+      MessageType.departureRequestValues must contain(DeclarationAmendment)
     }
 
     "DeclarationInvalidation" in {
       MessageType.values must contain(DeclarationInvalidation)
       DeclarationInvalidation.code mustEqual "IE014"
       DeclarationInvalidation.rootNode mustEqual "CC014C"
-      MessageType.departureValues must contain(DeclarationInvalidation)
+      MessageType.departureRequestValues must contain(DeclarationInvalidation)
     }
 
     "DeclarationData" in {
       MessageType.values must contain(DeclarationData)
       DeclarationData.code mustEqual "IE015"
       DeclarationData.rootNode mustEqual "CC015C"
-      MessageType.departureValues must contain(DeclarationData)
+      MessageType.departureRequestValues must contain(DeclarationData)
     }
 
     "PresentationNotificationForPreLodgedDec" in {
       MessageType.values must contain(PresentationNotificationForPreLodgedDec)
       PresentationNotificationForPreLodgedDec.code mustEqual "IE170"
       PresentationNotificationForPreLodgedDec.rootNode mustEqual "CC170C"
-      MessageType.departureValues must contain(PresentationNotificationForPreLodgedDec)
+      MessageType.departureRequestValues must contain(PresentationNotificationForPreLodgedDec)
     }
   }
 
   "find" - {
     "must return None when junk is provided" in forAll(Gen.stringOfN(6, Gen.alphaNumChar)) {
       code =>
-        MessageType.find(code) must not be defined
+        MessageType.find(code, true) must not be defined
     }
 
-    "must return the correct message type when a correct code is provided" in forAll(Gen.oneOf(MessageType.values)) {
+    "must return the correct message type when a correct code is provided for request types" in forAll(Gen.oneOf(MessageType.requestValues)) {
       messageType =>
-        MessageType.find(messageType.code) mustBe Some(messageType)
+        MessageType.find(messageType.code, true) mustBe Some(messageType)
+    }
+
+    "must return None when a correct code is provided for response types, when requestOnly is true" in forAll(Gen.oneOf(MessageType.responseValues)) {
+      messageType =>
+        MessageType.find(messageType.code, true) mustBe None
+    }
+
+    "must return the correct message type when a correct code is provided for all types" in forAll(Gen.oneOf(MessageType.values)) {
+      messageType =>
+        MessageType.find(messageType.code, false) mustBe Some(messageType)
     }
   }
 }

--- a/test/uk/gov/hmrc/transitmovementsvalidator/services/XmlValidationServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsvalidator/services/XmlValidationServiceSpec.scala
@@ -17,8 +17,6 @@
 package uk.gov.hmrc.transitmovementsvalidator.services
 
 import akka.stream.Materializer
-import akka.stream.scaladsl.FileIO
-import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.util.Timeout
@@ -33,7 +31,6 @@ import uk.gov.hmrc.transitmovementsvalidator.models.errors.ValidationError
 import uk.gov.hmrc.transitmovementsvalidator.models.errors.XmlSchemaValidationError
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.Paths
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.xml.NodeSeq


### PR DESCRIPTION
To enable validation response types, add -Dvalidate-request-types-only=false to the command line when starting the application